### PR TITLE
fix(ui): show error to user when git revert fails (#4)

### DIFF
--- a/src/components/history/HistoryPanel.tsx
+++ b/src/components/history/HistoryPanel.tsx
@@ -7,6 +7,15 @@ import { getHistory, revertCommit, type HistoryEntry } from "@/lib/tauri";
 export default function HistoryPanel() {
   const [entries, setEntries] = useState<HistoryEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!error) return;
+    const timeoutId = window.setTimeout(() => {
+      setError(null);
+    }, 3600);
+    return () => window.clearTimeout(timeoutId);
+  }, [error]);
 
   async function loadHistory() {
     try {
@@ -29,6 +38,7 @@ export default function HistoryPanel() {
       await loadHistory();
     } catch (e) {
       console.error("Failed to revert:", e);
+      setError(`Failed to revert: ${String(e)}`);
     }
   }
 
@@ -45,6 +55,12 @@ export default function HistoryPanel() {
           </svg>
         </button>
       </div>
+
+      {error && (
+        <div className="rounded-md border border-error/40 bg-error/[0.08] px-3 py-2 text-sm text-error">
+          {error}
+        </div>
+      )}
 
       {loading ? (
         <div className="flex justify-center py-8">


### PR DESCRIPTION
## What

Added visual error feedback to the History panel when a git revert operation fails.

## Why

- Addresses #4. 
Previously, if a revert failed (e.g., due to merge conflicts or I/O errors), the error was caught and logged to the console but not shown to the user. This basic error handling left users unsure if their action succeeded or failed.

## How

- Introduced a local `error` state in `HistoryPanel.tsx`.
- Updated `handleRevert` to catch errors and set the error message.
- Added a `useEffect` hook to auto-dismiss the error message after 3600ms, matching the UI pattern used in `Sidebar.tsx`.
- Added a conditional render block to display the error inline with the history list.

## Checklist

- [x] Only related files are included (no IDE configs, generated files, or local artifacts)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] `pnpm lint` passes
- [x] Manually tested the change
